### PR TITLE
fix favicon & MD linting; add docs/html to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/.vscode
 .development
+docs/html/

--- a/Doxyfile
+++ b/Doxyfile
@@ -1293,7 +1293,8 @@ HTML_EXTRA_STYLESHEET  = docs/doxygen_awesome/doxygen-awesome.css \
 # files will be copied as-is; there are no commands or markers available.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_EXTRA_FILES       = docs/doxygen_awesome/doxygen-awesome-darkmode-toggle.js
+HTML_EXTRA_FILES       = docs/doxygen_awesome/doxygen-awesome-darkmode-toggle.js \
+                         docs/img/favicon.ico
 
 # The HTML_COLORSTYLE_HUE tag controls the color of the HTML output. Doxygen
 # will adjust the colors in the style sheet and background images according to

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041 -->
 [![Arduino CLI Build](https://github.com/dstroy0/InputHandler/actions/workflows/build_arduino_cli.yml/badge.svg)](https://github.com/dstroy0/InputHandler/actions/workflows/build_arduino_cli.yml)  
 
 [![PlatformIO arduino CI](https://github.com/dstroy0/InputHandler/actions/workflows/build_arduino_pio.yml/badge.svg)](https://github.com/dstroy0/InputHandler/actions/workflows/build_arduino_pio.yml)  
@@ -7,7 +8,8 @@
 [![Doxygen CI](https://github.com/dstroy0/InputHandler/actions/workflows/doxygen.yml/badge.svg)](https://github.com/dstroy0/InputHandler/actions/workflows/doxygen.yml)  
 
 # InputHandler
-Arduino user input handler :  
+
+Arduino user input handler:  
 Executes arbitrary functions by matching user input command strings.  
 
 Check out the examples for different use cases.  You can use this library to build a remote cli for your equipment.  
@@ -15,22 +17,26 @@ Check out the examples for different use cases.  You can use this library to bui
 Commands are simple to setup, command length does not matter, any printable char or control char that is not your end of line character, token delimiter, or c-string delimiter is a valid command.  You can have as many or as few arguments as you wish.
 
 A command string looks like:  
-```
+
+```text
 your_command arg1 arg... "c-string args can have spaces and are enclosed with quotes"
 ```
 
 The classes' input methods are:  
 
-```
+```cpp
 void GetCommandFromStream(Stream &stream, uint16_t rx_buffer_size = 32);
 ```
-OR if you dont want to use a [Stream](https://www.arduino.cc/reference/en/language/functions/communication/stream/) object use:  
-```
+
+OR if you don't want to use a [Stream](https://www.arduino.cc/reference/en/language/functions/communication/stream/) object use:  
+
+```cpp
 void ReadCommandFromBuffer(uint8_t *data, size_t len);
 ```
 
 Easily enforce input argument types with:  
-```
+
+```cpp
 const UITYPE your_arguments_in_order[] = {UITYPE::UINT8_T,
                                           UITYPE::UINT16_T,
                                           UITYPE::UINT32_T,
@@ -46,21 +52,26 @@ UserCommandParameters your_command_object_("your_input_to_match",    // your com
                                            your_arguments_in_order  // your argument array
                                           );                           
 ```
-NOTYPE is a special argument type that doesn't perform any type-validation.
 
+`NOTYPE` is a special argument type that doesn't perform any type-validation.
 
 Class output is enabled by defining a buffer, the class methods format the buffer into useful human readable information.  
 
 This method will output to any stream (hardware or software Serial):  
-```
+
+```cpp
 void OutputToStream(Stream &stream);
 ```
+
 or, you can check to see if output is available with:  
-```
+
+```cpp
 bool OutputIsAvailable();
 ```
+
 and then when you are done with the output buffer, it needs to be reinitialized with:  
-```
+
+```cpp
 void ClearOutputBuffer();
 ```
 
@@ -68,7 +79,8 @@ The input process will continue to function even if you do not define an output 
 
 Target function will not execute if the command string does not match, or any arguments are type-invalid.  
 
-# Supported Platforms    
+# Supported Platforms
+
 ATTiny85 not supported  
 
 If your board is not listed as not supported open an issue if you'd like it added to build coverage.  
@@ -95,7 +107,7 @@ esplora
 mini  
 ethernet  
 fio  
-bt   
+bt
 LilyPadUSB  
 pro  
 atmegang  

--- a/docs/doxygen-custom/header.html
+++ b/docs/doxygen-custom/header.html
@@ -22,7 +22,7 @@
 <!--BEGIN PROJECT_NAME--><title>$projectname: $title</title><!--END PROJECT_NAME-->
 <!--BEGIN !PROJECT_NAME--><title>$title</title><!--END !PROJECT_NAME-->
 <link href="$relpath^tabs.css" rel="stylesheet" type="text/css"/>
-<link rel="icon" type="image/svg+xml" href="logo.drawio.svg"/>
+<link rel="alternate icon" type="image" href="favicon.ico"/>
 <script type="text/javascript" src="$relpath^jquery.js"></script>
 <script type="text/javascript" src="$relpath^dynsections.js"></script>
 <script type="text/javascript" src="$relpath^doxygen-awesome-darkmode-toggle.js"></script>


### PR DESCRIPTION
Saw some easy fixes about the docs, so I figured I'd submit these changes:

- Properly use favicon.ico which reuires some extra info in the Doxyfile
 
   On a side note, I noticed the logo is using a white background which kinda sticks out in the docs when using the dark theme. I didn't see the logo image's source file, so I didn't make any changes to the logo. I was able to hack something with GIMP, but the letters (especially the "e") looked rather ugly without the white infill.
- Locally, I use the [markdownlint extension in VSCode](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint). This repo's README.md had some "violations" (linter's term - not my preferred term) that were easily addressed.
- The generated docs can be inspected locally by running
   ```
   doxygen
   ```
   at the repo's root folder. This technique also requires that the gitignore file exclude any changes to the Doxygen HTML output folder (specified in the Doxyfile as _docs/html_).

---
I noticed the Doxyfile was generated (or at least last updated) by Doxygen v1.9.1. However, the CI is running v1.9.3. The Doxyfile should easily be updated by running 
```
doxygen -u
```
This is not that important, and IDK which version of doxygen you're using locally. This is why I'm only mentioning it but not doing anything about it.